### PR TITLE
Exclude TypeScript definitions of dependencies from builds

### DIFF
--- a/dist/nominatim-browser.d.ts
+++ b/dist/nominatim-browser.d.ts
@@ -1,4 +1,3 @@
-/// <reference path="../typings/browser.d.ts" />
 import * as Promise from "bluebird";
 export declare class NaminatimError extends Error {
     requestData: XMLHttpRequest;

--- a/dist/nominatim-browser.js
+++ b/dist/nominatim-browser.js
@@ -1,4 +1,3 @@
-/// <reference path="./typings/browser.d.ts" />
 "use strict";
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];

--- a/dist/nominatim-browser.webpacked.js
+++ b/dist/nominatim-browser.webpacked.js
@@ -45,7 +45,6 @@ var Nominatim =
 /* 0 */
 /***/ function(module, exports, __webpack_require__) {
 
-	/// <reference path="./typings/browser.d.ts" />
 	"use strict";
 	var __extends = (this && this.__extends) || function (d, b) {
 	    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,6 +11,7 @@ var tsconfig = require("./tsconfig");
 var sequence = require('run-sequence');
 
 var tsOptions = tsconfig.compilerOptions;
+var tsFiles = tsconfig.files;
 
 var webpackOptions = {
     externals: { },
@@ -25,7 +26,7 @@ var webpackOptions = {
 
 gulp.task("lib", function ()
 {
-    var tsBuild = gulp.src("nominatim-browser.ts")
+    var tsBuild = gulp.src(tsFiles)
         .pipe(ts(ts.createProject("./tsconfig.json"), {declaration: true}));
     
     var buildDefinition = tsBuild

--- a/nominatim-browser.ts
+++ b/nominatim-browser.ts
@@ -1,5 +1,3 @@
-/// <reference path="./typings/browser.d.ts" />
-
 import * as Promise from "bluebird";
 import * as reqwest from "reqwest";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
         "declaration": true
     },
     "files": [
+        "typings/browser.d.ts",
         "nominatim-browser.ts"
     ]
 }


### PR DESCRIPTION
These definitions included global definition files for `chai` and `mocha`. These can conflict with library consumer's global symbols, like, in my case, `jest`'s.

Now I'm not sure what this changes for library consumers. It fixes my issues with the global `mocha` symbols and TypeScript doesn't complain about missing `bluebird` or `reqwest` symbols. TypeScript's definition loading still confuses me. So only merge this if you're sure about the consequences.