### PR TITLE
Added ability to specify a different URL for Nominatim

### DIFF
--- a/nominatim-browser.ts
+++ b/nominatim-browser.ts
@@ -210,15 +210,17 @@ export interface NominatimResponse {
     extratags: any;
 }
 
+const NOMINATIM_URL: string = 'https://nominatim.openstreetmap.org';
+
 /**
 Creates a webrequest to the given path.
 */
-function createRequest<T>(path: string, data: Object = {}) {
+function createRequest<T>(path: string, data: Object = {}, nominatimUrl: string) {
     //Result should be in JSON
     data["format"] = "json";
 
     const request = Axios({
-        url: `https://nominatim.openstreetmap.org/${path}`,
+        url: `${nominatimUrl}/${path}`,
         method: "GET",
         params: data,
         responseType: "json",
@@ -254,8 +256,8 @@ function finishRequest<T>(request: Axios.IPromise<Axios.AxiosXHR<T>>) {
  * @param path The request's path.
  * @param data The request's optional querystring or body data object.
  */
-function handleFullRequest<T>(path: string, data?: any) {
-    var request = createRequest(path, data);
+function handleFullRequest<T>(path: string, nominatimUrl: string, data?: any) {
+    var request = createRequest(path, data, nominatimUrl);
 
     return finishRequest<T>(request);
 };
@@ -263,20 +265,20 @@ function handleFullRequest<T>(path: string, data?: any) {
 /**
  * Lookup the latitude and longitude data for a given address.
  */
-export function geocode(data: GeocodeRequest) {
-    return handleFullRequest<NominatimResponse[]>("search", data);
+export function geocode(data: GeocodeRequest, nominatimUrl: string = NOMINATIM_URL) {
+    return handleFullRequest<NominatimResponse[]>("search", nominatimUrl, data);
 }
 
 /**
  * Lookup the address data for a pair of latitude and longitude coordinates.
  */
-export function reverseGeocode(data: ReverseGeocodeRequest) {
-    return handleFullRequest<NominatimResponse>("reverse", data);
+export function reverseGeocode(data: ReverseGeocodeRequest, nominatimUrl: string = NOMINATIM_URL) {
+    return handleFullRequest<NominatimResponse>("reverse", nominatimUrl, data);
 }
 
 /**
  * Lookup the address of one or multiple OSM objects like node, way or relation. 
  */
-export function lookupAddress(data: LookupRequest) {
-    return handleFullRequest<NominatimResponse[]>("lookup", data);
+export function lookupAddress(data: LookupRequest, nominatimUrl: string = NOMINATIM_URL) {
+    return handleFullRequest<NominatimResponse[]>("lookup", nominatimUrl, data);
 }

--- a/tests/geocode.ts
+++ b/tests/geocode.ts
@@ -16,10 +16,9 @@ export class GeocodeFixture {
         Expect(results.length >= 1).toBe(true);
 
         const result = results[0];
-
-        Expect(typeof (result.place_id)).toBe("string");
+        Expect(typeof (result.place_id)).toBe("number");
         Expect(typeof (result.licence)).toBe("string");
-        Expect(typeof (result.osm_id)).toBe("string");
+        Expect(typeof (result.osm_id)).toBe("number");
         Expect(typeof (result.lat)).toBe("string");
         Expect(typeof (result.lon)).toBe("string");
         Expect(result.display_name).toEqual("Minneapolis, Hennepin County, Minnesota, United States of America");
@@ -39,9 +38,9 @@ export class GeocodeFixture {
 
         const result = results[0];
 
-        Expect(typeof(result.place_id)).toBe("string");
+        Expect(typeof(result.place_id)).toBe("number");
         Expect(typeof(result.licence)).toBe("string");
-        Expect(typeof(result.osm_id)).toBe("string");
+        Expect(typeof(result.osm_id)).toBe("number");
         Expect(typeof(result.lat)).toBe("string");
         Expect(typeof(result.lon)).toBe("string");
         Expect(result.display_name).toEqual("Minneapolis, Hennepin County, Minnesota, United States of America");

--- a/tests/lookup.ts
+++ b/tests/lookup.ts
@@ -14,7 +14,7 @@ export class LookupTestFixture {
         
         const result = results[0];
         
-        Expect(typeof(result.place_id)).toBe("string");
+        Expect(typeof(result.place_id)).toBe("number");
         Expect(typeof(result.licence)).toBe("string");
         Expect(typeof(result.lat)).toBe("string");
         Expect(typeof(result.lon)).toBe("string");

--- a/tests/reverseGeocode.ts
+++ b/tests/reverseGeocode.ts
@@ -13,11 +13,11 @@ export class ReverseGeocodeTestFixture {
     public async reverseGeocode() {
         const result = await reverseGeocode(ReverseGeocodeTestFixture.MINNEAPOLIS_LAT_LONG);
 
-        Expect(typeof (result.place_id)).toBe("string");
+        Expect(typeof (result.place_id)).toBe("number");
         Expect(typeof (result.licence)).toBe("string");
         Expect(typeof (result.lat)).toBe("string");
         Expect(typeof (result.lon)).toBe("string");
-        Expect(result.display_name).toEqual("Minneapolis City Hall, South 4th Street, St Anthony West, Phillips, Minneapolis, Hennepin County, Minnesota, 55415, United States of America");
+        Expect(result.display_name).toEqual("Minneapolis City Hall, Government Center Plaza, St Anthony West, Phillips, Minneapolis, Hennepin County, Minnesota, United States of America");
     }
 
     @AsyncTest(".reverseGeocodeWithAddress(): Should return address data for coordinates")
@@ -28,11 +28,11 @@ export class ReverseGeocodeTestFixture {
             ...ReverseGeocodeTestFixture.MINNEAPOLIS_LAT_LONG
         });
 
-        Expect(typeof (result.place_id)).toBe("string");
+        Expect(typeof (result.place_id)).toBe("number");
         Expect(typeof (result.licence)).toBe("string");
         Expect(typeof (result.lat)).toBe("string");
         Expect(typeof (result.lon)).toBe("string");
-        Expect(result.display_name).toEqual("Minneapolis City Hall, South 4th Street, St Anthony West, Phillips, Minneapolis, Hennepin County, Minnesota, 55415, United States of America");
+        Expect(result.display_name).toEqual("Minneapolis City Hall, Government Center Plaza, St Anthony West, Phillips, Minneapolis, Hennepin County, Minnesota, United States of America");
         Expect(result.address).not.toBeNull();
         Expect(result.address).toBeDefined();
 


### PR DESCRIPTION
I've added an optional parameter for the 3 Nominatim API calls to specify the Nominatim URL.
The use case for this is if you need to use this in an offline environment with a private instance of Nominatim.

Also took the liberty to fix the tests as it seems their were failing, probably because Nomatin changed their response and not because the code had any issues itself.